### PR TITLE
Fix dictionary changed size during iteration on Python3

### DIFF
--- a/asgi_amqp/core.py
+++ b/asgi_amqp/core.py
@@ -154,7 +154,7 @@ class AMQPChannelLayer(BaseChannelLayer):
                 channels = jsonpickle.decode(g.channels)
                 channels.update({channel: ts})
 
-            for c, ts in channels.items():
+            for c, ts in list(channels.items()):
                 now = datetime.datetime.utcnow()
                 if (now - ts).total_seconds() > self.group_expiry:
                     del channels[c]


### PR DESCRIPTION
Principaly on Python3 but can occur on Python3.

On group_add function, if items are received during iteration, the dictionary change size and throw RuntimeError : dictionary changed size during iteration

To avoid them, it's better to get a fixed list before iterate.