### PR TITLE
auto-ack messages

### DIFF
--- a/asgi_amqp/core.py
+++ b/asgi_amqp/core.py
@@ -64,7 +64,7 @@ class AMQPChannelLayer(BaseChannelLayer):
         if not hasattr(self.tdata, 'consumer'):
             self.tdata.consumer = self.tdata.connection.Consumer([], callbacks=[self.on_message],
                                                                  accept=['msgpack', 'application/msgpack'],
-                                                                 no_ack=False)
+                                                                 no_ack=True)
         if not hasattr(self.tdata, 'buffer'):
             self.tdata.buffer = deque()
 
@@ -121,7 +121,6 @@ class AMQPChannelLayer(BaseChannelLayer):
             if self.tdata.buffer:
                 message = self.tdata.buffer.popleft()
                 channel = routing_key_to_channel(message.delivery_info['routing_key'])
-                message.ack()
                 return channel, self.deserialize(message.body)
 
             try:


### PR DESCRIPTION
* A deadlock can occur when an error happens between consuming a message
and acking a message. This problem is compounded by the fact that our
messages have no TTL and our QoS settings only allow for 1 messages to
be consumed at a time.
* This change fixes the deadlock by auto-acking messages that are
consumed. We are safe to do this because of the nature of websocket
messages, they are transient. They do not require guaranteed delivery.