### PR TITLE
Upgrade from deprecated library to its replacement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         'six',
         'kombu>=3.0.35',
-        'msgpack-python>=0.4.7',
+        'msgpack>=0.6.1',
         'asgiref==1.1.2',
         'jsonpickle>=0.9.3',
     ],


### PR DESCRIPTION
https://pypi.org/project/msgpack-python/

> This package is deprecated. Install msgpack instead.

The [problem](https://github.com/ansible/awx/pull/3682) I had is that I was getting unexpected import warnings. Replace locally with this project folder:

```
$ python -W error -c "from asgi_amqp import core"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/alancoding/Documents/repos/asgi_amqp/asgi_amqp/__init__.py", line 5, in <module>
    from .core import AMQPChannelLayer # noqa
  File "/Users/alancoding/Documents/repos/asgi_amqp/asgi_amqp/core.py", line 9, in <module>
    import msgpack
  File "/Users/alancoding/.virtualenvs/asgi_amqp_py3/lib/python3.6/site-packages/msgpack/__init__.py", line 25, in <module>
    from msgpack._packer import Packer
  File "msgpack/_packer.pyx", line 8, in init msgpack._packer
ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
```

I would write a test for this, but unfortunately this is a warning that pytest itself filters out, and I can't find a way to un-suppress that warning.

After upgrading the dependency and re-installing, I do find that `python -W error -c "from asgi_amqp import core"` runs and exists without error.